### PR TITLE
feat(ODP-1): Implemented circleci cli docker build files.

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG.md
+++ b/.github/ISSUE_TEMPLATE/BUG.md
@@ -1,11 +1,11 @@
----
+<---
 name: "\U0001F41E  Bug report"
 about: Report any bugs encountered while using this orb.
 title: ''
 labels: bug
 assignees: ''
 
----
+--->
 
 ## Orb version:
 

--- a/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE_REQUEST.md
@@ -6,9 +6,11 @@ labels: feature_request
 assignees: ''
 ---
 
-## Describe Request:
+## Feature Request Title
 
-## Examples:
+### Describe Request:
 
-## Supporting Documentation Links:
+### Examples:
+
+### Supporting Documentation Links:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
- - Current development changes [ to be moved to release ]
+ - [ODP-1](https://github.com/serbiatech/ci-orb-docker-publisher/issues/1) Implement CircleCI CLI for local jobs execution. [ to be moved to release ]
 
+<!---
 ## [1.0.0] - YYYY-MM-DD
 ### Added
  - Initial Release
@@ -17,3 +18,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 [1.0.0]: GITHUB TAG URL
+-->

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+# Jobs constants
+
+BATS_JOB=bats/run
+LINT_JOB=orb-tools/lint
+PACK_JOB=orb-tools/pack
+SHELLCHECK_JOB=shellcheck/check
+
+# Config options replace config
+
+LINT_OPTIONS_REPLACE="custom-rules-filepath=.yamllint>custom-rules-filepath=/tmp/_circleci_local_build_repo/.yamllint"
+
+# Commands
+
+lint:
+	/bin/bash /home/sphere-master/circleci-local-execute.sh ${LINT_JOB} ${LINT_OPTIONS_REPLACE}
+
+pack:
+	/bin/bash /home/sphere-master/circleci-local-execute.sh ${PACK_JOB}
+
+shellcheck:
+	/bin/bash /home/sphere-master/circleci-local-execute.sh ${SHELLCHECK_JOB}
+
+bats:
+	/bin/bash /home/sphere-master/circleci-local-execute.sh ${BATS_JOB}
+
+local-execute:
+	/bin/bash /home/sphere-master/circleci-local-execute.sh $(job) $(optionsReplace)
+
+help:
+	# Usage:
+	#   make <target> [OPTION=value]
+	#
+	# Targets:
+	#	lint			Run lint tests on src folder
+	#	pack			Run orb packing and validation
+	#	shellcheck		Run shellcheck tests on src/scripts folder
+	#	bats			Run bats tests on src/scripts folder
+	#   local-execute   Run job locally where option job=<job name from .circleci/config.yml> is required
+	#
+	#   help            You're looking at it!

--- a/docker/.env
+++ b/docker/.env
@@ -1,0 +1,22 @@
+#####################################
+##   Docker compose project name   ##
+#####################################
+COMPOSE_PROJECT_NAME=ci-orb-docker-publisher
+
+#########################################
+##   User root and project directory   ##
+#########################################
+USER_HOME_DIR=/c/Users/nelle
+USER_PROJECTS_DIR=Projects
+
+##############################################
+##   Container user and group id settings   ##
+##############################################
+ENV_USER_ID=1000
+ENV_GROUP_ID=1000
+
+##################################################
+##   Container timezone and language settings   ##
+##################################################
+ENV_TIMEZONE=UTC
+ENV_LANGUAGE=en_US.UTF-8

--- a/docker/.env
+++ b/docker/.env
@@ -6,8 +6,8 @@ COMPOSE_PROJECT_NAME=ci-orb-docker-publisher
 #########################################
 ##   User root and project directory   ##
 #########################################
-USER_HOME_DIR=/c/Users/nelle
-USER_PROJECTS_DIR=Projects
+USER_CIRCLECI_DIR=/c/Users/nelle/.circleci
+USER_PROJECTS_DIR=/c/Users/nelle/Projects
 
 ##############################################
 ##   Container user and group id settings   ##

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,43 @@
+# Docker
+
+Docker publisher orb project comes already with prepared setup for running circleci client.
+
+## Pre-requirements
+
+- **Docker desktop** - Instructions for installing Docker desktop on your machine can be found on [Get Docker](https://docs.docker.com/get-docker/).
+- **CircleCi Token** - Instructions on generating personal API token can be found here ([Managing Api Tokens](https://circleci.com/docs/2.0/managing-api-tokens/)). After you obtain
+your personal API token you should create `cli.yml` in `<your-home-dir>\.circleci` (example: `C:\Users\SomeUser\.circleci`) that should contain:
+  
+```yaml
+  
+  host: https://circleci.com
+  endpoint: graphql-unstable
+  token: <your-circleci-access-token>
+  rest_endpoint: api/v2
+  orb_publishing:
+    default_namespace: serbiatech
+    default_vcs_provider: github
+    default_owner: serbiatech
+  
+  ```
+- **USER_CIRCLECI_DIR and USER_PROJECTS_DIR** - In `docker/.env` set this two variable according to your host setup (example: `USER_CIRCLECI_DIR=/c/Users/SomeUser/.circleci`, `USER_PROJECTS_DIR=/c/Users/SomeUser/Projects`)
+
+## Running orb-cli container
+
+To build and run orb-cli container type:`cd docker` and then `docker-compose up -d`. After container is build you can access container by typing `docker-compose exec orb-cli bash`.
+
+## Running jobs
+
+You can execute jobs on local machine by typing `docker-compose exec orb-cli make local-execute <job-name>`, but there are also predifined job commands:
+
+- **docker-compose exec orb-cli make lint** - executes `orb-tools/lint` job.
+- **docker-compose exec orb-cli make pack** - executes `orb-tools/pack` job.
+- **docker-compose exec orb-cli make shellcheck** - executes `shellcheck/check` job.
+- **docker-compose exec orb-cli make bats** - executes `bats/run` job.
+
+## Stopping container and removing images
+
+For stopping container type `docker-compose down` and for removing all images type `docker system prune -a` and then `y`.
+
+
+

--- a/docker/circleci-cli/Dockerfile
+++ b/docker/circleci-cli/Dockerfile
@@ -1,0 +1,105 @@
+FROM alpine:latest
+
+MAINTAINER Nenad Stefanovic <stefanovic21@sbb.rs>
+
+# SYS: Set build arguments
+
+ARG MUSL_LOCPATH=/usr/share/i18n/locales/musl
+
+ARG HOST_USER_ID
+
+ARG HOST_GROUP_ID
+
+ARG CONTAINER_LANGUAGE
+
+ARG CONTAINER_TIMEZONE
+
+# SYS: Set environments
+
+ENV USER=sphere-master
+
+ENV HOME /home/$USER
+
+ENV LANG=$CONTAINER_LANGUAGE
+
+ENV LANGUAGE=$CONTAINER_LANGUAGE
+
+ENV LC_ALL=$CONTAINER_LANGUAGE
+
+## SYS: Install required packages
+
+RUN apk update && \
+	apk --no-cache upgrade && \
+    apk add \
+    	autoconf \
+    	bash \
+    	cmake \
+    	curl \
+    	docker-cli \
+        g++ \
+    	gcc \
+    	gettext \
+        gettext-dev \
+    	make \
+    	musl-dev \
+    	shadow \
+    	sudo \
+    	tzdata \
+    	jq
+
+RUN apk add --no-cache \
+    $MUSL_LOCALE_DEPS && \
+    wget https://gitlab.com/rilian-la-te/musl-locales/-/archive/master/musl-locales-master.zip && \
+    unzip musl-locales-master.zip && \
+    cd musl-locales-master && \
+    cmake -DLOCALE_PROFILE=OFF -D CMAKE_INSTALL_PREFIX:PATH=/usr . && \
+    make && \
+    make install && \
+    cd .. && \
+    rm -r musl-locales-master
+
+RUN curl -fLSs https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh | bash
+
+# SYS: Set container timezone
+
+RUN ln -snf "/usr/share/zoneinfo/$CONTAINER_TIMEZONE" /etc/localtime && \
+    echo "$CONTAINER_TIMEZONE" > /etc/timezone
+
+# SYS: Remove /etc/dpkg that get's installed with $PHPIZE_DEPS
+
+RUN rm -rf /etc/dpkg
+
+# SYS: Add sphere-master user
+
+RUN adduser -D $USER && \
+    echo "$USER ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers
+
+# SYS: Set sphere-master user and group id
+
+RUN /bin/bash -c 'if [ -n $HOST_USER_ID ] && [ $HOST_USER_ID -lt 60000 ]; then \
+        usermod -u $HOST_USER_ID $USER; \
+    fi'
+
+RUN /bin/bash -c 'if [ -n $HOST_GROUP_ID ] && [ $HOST_GROUP_ID -lt 60000 ]; then \
+        groupmod -g $HOST_GROUP_ID $USER; \
+    fi'
+
+# SYS: Copy local execute script
+
+COPY --chown=$USER:$USER scripts/circleci-local-execute.sh $HOME/circleci-local-execute.sh
+
+# SYS: Copy startup script
+
+COPY --chown=$USER:$USER scripts/startup.sh $HOME/startup.sh
+
+# SYS: Set sphere-master as current user
+
+USER $USER
+
+# SYS: Change working dir
+
+WORKDIR $HOME/project
+
+# SYS: Trigger startup script
+
+CMD ["/home/sphere-master/startup.sh"]

--- a/docker/circleci-cli/scripts/circleci-local-execute.sh
+++ b/docker/circleci-cli/scripts/circleci-local-execute.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# Constants
+
+DOCKER_SOCKET=/var/run/docker.sock
+CIRCLECI_CONFIG=.circleci/config.yml
+CIRCLECI_TEMPORARY_CONFIG=tmp_config.yml
+CIRCLECI_LOCAL_BUILD_CONFIG=local_build_config.yml
+CIRCLECI_LOCAL_BUILD_REPOSITORY=/tmp/_circleci_local_build_repo
+
+# Read job name and options replace from input
+
+JOB_NAME=$1
+OPTIONS_REPLACE=$2
+
+# Remove old config files if they exists
+
+rm -f "${CIRCLECI_LOCAL_BUILD_CONFIG}"
+rm -f "${CIRCLECI_TEMPORARY_CONFIG}"
+
+# Process local build config
+
+if [ -n "${OPTIONS_REPLACE}" ]
+then
+  cp "${CIRCLECI_CONFIG}" "${CIRCLECI_TEMPORARY_CONFIG}"
+
+  IFS='|' read -r -a options <<< "${OPTIONS_REPLACE}"
+  unset IFS
+
+  for option in "${options[@]}"
+  do
+    set -e
+    search=$(echo "${option}" | cut -d'>' -f1)
+    replace=$(echo "${option}" | cut -d'>' -f2)
+
+    searchPattern="$(echo "${search}" | cut -d'=' -f1): $(echo "${search}" | cut -d'=' -f2)"
+    replacePattern="$(echo "${replace}" | cut -d'=' -f1): $(echo "${replace}" | cut -d'=' -f2)"
+
+    sed -i -e "s|${searchPattern}|${replacePattern}|" "${CIRCLECI_TEMPORARY_CONFIG}"
+
+    circleci config process "${CIRCLECI_TEMPORARY_CONFIG}" >> "${CIRCLECI_LOCAL_BUILD_CONFIG}"
+    rm -f "${CIRCLECI_TEMPORARY_CONFIG}"
+  done
+else
+  circleci config process "${CIRCLECI_CONFIG}" >> "${CIRCLECI_LOCAL_BUILD_CONFIG}"
+fi
+
+# Run command for the local execution of the job
+
+docker run -v "${DOCKER_SOCKET}":"${DOCKER_SOCKET}" \
+       -v "${HOST_PROJECT_ROOT}":"${CIRCLECI_LOCAL_BUILD_REPOSITORY}" \
+       -w "${HOST_PROJECT_ROOT}" \
+       circleci/picard circleci execute \
+       -c "${CIRCLECI_LOCAL_BUILD_REPOSITORY}"/"${CIRCLECI_LOCAL_BUILD_CONFIG}" \
+       --job "${JOB_NAME}"
+
+# Remove local build config
+
+rm -f "${CIRCLECI_LOCAL_BUILD_CONFIG}"

--- a/docker/circleci-cli/scripts/startup.sh
+++ b/docker/circleci-cli/scripts/startup.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# SYS: Set user permission for docker socket
+
+sudo chmod 666 /var/run/docker.sock
+
+# SYS: Make orb-cli stay running
+
+tail -f /dev/null

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3.8'
+
+services:
+  orb-cli:
+    build:
+      context: ./circleci-cli
+      dockerfile: Dockerfile
+      args:
+        HOST_USER_ID: ${ENV_USER_ID}
+        HOST_GROUP_ID: ${ENV_GROUP_ID}
+        CONTAINER_LANGUAGE: ${ENV_LANGUAGE}
+        CONTAINER_TIMEZONE: ${ENV_TIMEZONE}
+    image: docker-publisher-orb-cli:1.0
+    hostname: docker-publisher-orb-cli
+    container_name: docker-publisher-orb-cli
+    environment:
+      HOST_PROJECT_ROOT: ${USER_HOME_DIR}/${USER_PROJECTS_DIR}/${COMPOSE_PROJECT_NAME}
+    networks:
+      - docker-publisher-orb-network
+    volumes:
+      - ${USER_HOME_DIR}/.circleci:/home/sphere-master/.circleci:rw
+      - /var/run/docker.sock:/var/run/docker.sock:rw
+      - ../:/home/sphere-master/project:rw
+
+networks:
+  docker-publisher-orb-network:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,11 +14,11 @@ services:
     hostname: docker-publisher-orb-cli
     container_name: docker-publisher-orb-cli
     environment:
-      HOST_PROJECT_ROOT: ${USER_HOME_DIR}/${USER_PROJECTS_DIR}/${COMPOSE_PROJECT_NAME}
+      HOST_PROJECT_ROOT: ${USER_PROJECTS_DIR}/${COMPOSE_PROJECT_NAME}
     networks:
       - docker-publisher-orb-network
     volumes:
-      - ${USER_HOME_DIR}/.circleci:/home/sphere-master/.circleci:rw
+      - ${USER_CIRCLECI_DIR}/:/home/sphere-master/.circleci:rw
       - /var/run/docker.sock:/var/run/docker.sock:rw
       - ../:/home/sphere-master/project:rw
 


### PR DESCRIPTION
## Description:

- Added `docker/orb-cli/scripts/circleci-local-execute.sh` script for local job execution.
- Added `docker/orb-cli/scripts/startup.sh` script for setting docker socket permission.
- Added `docker/orb-cli/Dockerfile` for building orb-cli alpine image.
- Added `docker/docker-compose.yml` file for docker build configuration.
- Added `docker/.env` file that contains ENVIRONMENT variables.
- Added `docker/README.md` file with docker installation and running instructions.
- Added `Makefile` with commands for executing jobs locally.

## Motivation:

The idea behind this PR is to have docker build environment which will add ability to execute jobs such as bats tests, lint tests, pack orb on local machine . The main goal is to have independent environment which is capable running ` circleci local execute <job-name>` command. This will overcome circleci cli limitation when running on different OS (Linux, Windows, MacOS).

 **Closes Issues:**
-  [#ODP-1](https://github.com/serbiatech/ci-orb-docker-publisher/issues/1)

## Checklist:

- [x] All new features have descriptions in their appropriate `README.md.` files.
- [x] All new features are covered with tests.
- [x] Changelog has been updated.