### PR TITLE
feat(ODP-2): Implement set and remove build directory commands.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
- - [ODP-1](https://github.com/serbiatech/ci-orb-docker-publisher/issues/1) Implement CircleCI CLI for local jobs execution. [ to be moved to release ]
+ - [#ODP-1](https://github.com/serbiatech/ci-orb-docker-publisher/issues/1) Implemented CircleCI CLI for local jobs execution. [ to be moved to release ]
+ - [#ODP-2](https://github.com/serbiatech/ci-orb-docker-publisher/issues/4) Implemented create build directory command. [ to be moved to release ]
+ - [#ODP-2](https://github.com/serbiatech/ci-orb-docker-publisher/issues/4) Implemented remove build directory command. [ to be moved to release ]
 
 <!---
 ## [1.0.0] - YYYY-MM-DD

--- a/docker/circleci-cli/scripts/circleci-local-execute.sh
+++ b/docker/circleci-cli/scripts/circleci-local-execute.sh
@@ -47,6 +47,8 @@ fi
 
 # Run command for the local execution of the job
 
+echo y | docker system prune -a
+
 docker run -v "${DOCKER_SOCKET}":"${DOCKER_SOCKET}" \
        -v "${HOST_PROJECT_ROOT}":"${CIRCLECI_LOCAL_BUILD_REPOSITORY}" \
        -w "${HOST_PROJECT_ROOT}" \

--- a/src/commands/remove-build-dir.yml
+++ b/src/commands/remove-build-dir.yml
@@ -1,0 +1,13 @@
+description: >
+  This command will remove "./docker-publisher-build/" folder from the root directory of your project.
+parameters:
+  buildDir:
+    type: string
+    default: "./docker-publisher-build/"
+    description: "Path to the build directory."
+steps:
+  - run:
+      environment:
+        BUILD_DIR: <<parameters.buildDir>>
+      name: Remove build directory
+      command: <<include(scripts/remove-build-dir.sh)>>

--- a/src/commands/set-build-dir.yml
+++ b/src/commands/set-build-dir.yml
@@ -1,0 +1,13 @@
+description: >
+  This command will create "./docker-publisher-build/" folder in the root directory of your project.
+parameters:
+  buildDir:
+    type: string
+    default: "./docker-publisher-build/"
+    description: "Path to the build directory."
+steps:
+  - run:
+      environment:
+        BUILD_DIR: <<parameters.buildDir>>
+      name: Set build directory
+      command: <<include(scripts/set-build-dir.sh)>>

--- a/src/scripts/remove-build-dir.sh
+++ b/src/scripts/remove-build-dir.sh
@@ -1,0 +1,9 @@
+RemoveBuildDir() {
+
+    rm -rf "${BUILD_DIR}"
+}
+
+ORB_TEST_ENV="bats-core"
+if [ "${0#*$ORB_TEST_ENV}" == "$0" ]; then
+    RemoveBuildDir
+fi

--- a/src/scripts/set-build-dir.sh
+++ b/src/scripts/set-build-dir.sh
@@ -1,0 +1,12 @@
+SetBuildDir() {
+
+  rm -rf "${BUILD_DIR}orderedInheritanceList.txt"
+  rm -rf "${BUILD_DIR}unorderedInheritanceList.txt"
+
+  mkdir -p "${BUILD_DIR}"
+}
+
+ORB_TEST_ENV="bats-core"
+if [ "${0#*$ORB_TEST_ENV}" == "$0" ]; then
+    SetBuildDir
+fi

--- a/src/tests/remove-build-dir.bats
+++ b/src/tests/remove-build-dir.bats
@@ -1,0 +1,26 @@
+setup() {
+
+    source ./src/scripts/remove-build-dir.sh
+}
+
+@test 'remove-build-dir-command: Remove old directory with files.' {
+
+    export BUILD_DIR="./build/"
+
+    mkdir -p "${BUILD_DIR}"
+
+    echo "namespace/test-image" >> "${BUILD_DIR}orderedInheritanceList.txt"
+    echo "namespace/test-image" >> "${BUILD_DIR}unorderedInheritanceList.txt"
+
+    [ -d "${BUILD_DIR}" ]
+    [ -f "${BUILD_DIR}orderedInheritanceList.txt" ]
+    [ -f "${BUILD_DIR}unorderedInheritanceList.txt" ]
+
+    RemoveBuildDir
+
+    [ ! -f "${BUILD_DIR}orderedInheritanceList.txt" ]
+    [ ! -f "${BUILD_DIR}unorderedInheritanceList.txt" ]
+    [ ! -d "${BUILD_DIR}" ]
+
+    rm -rf "${BUILD_DIR}"
+}

--- a/src/tests/remove-build-dir.bats
+++ b/src/tests/remove-build-dir.bats
@@ -5,7 +5,7 @@ setup() {
 
 @test 'remove-build-dir-command: Remove old directory with files.' {
 
-    export BUILD_DIR="./build/"
+    export BUILD_DIR="./docker-publisher-build/"
 
     mkdir -p "${BUILD_DIR}"
 

--- a/src/tests/set-build-dir.bats
+++ b/src/tests/set-build-dir.bats
@@ -3,7 +3,7 @@ setup() {
     source ./src/scripts/set-build-dir.sh
 }
 
-@test 'set-build-dir-command: Create empty directory' {
+@test 'set-build-dir-command: Create empty directory.' {
 
     export BUILD_DIR="./build/"
 
@@ -20,7 +20,7 @@ setup() {
     rm -rf "${BUILD_DIR}"
 }
 
-@test 'set-build-dir-command: Remove old directory with files and create empty directory' {
+@test 'set-build-dir-command: Remove old directory with files and create empty directory.' {
 
     export BUILD_DIR="./build/"
 

--- a/src/tests/set-build-dir.bats
+++ b/src/tests/set-build-dir.bats
@@ -1,0 +1,15 @@
+setup() {
+
+    source ./src/scripts/set-build-dir.sh
+}
+
+@test 'set-build-dir-command: Create empty build directory' {
+
+    export BUILD_DIR="./build/"
+
+    ! [ -d "${BUILD_DIR}" ]
+
+    SetBuildDir
+
+    [ -d "${BUILD_DIR}" ]
+}

--- a/src/tests/set-build-dir.bats
+++ b/src/tests/set-build-dir.bats
@@ -5,7 +5,7 @@ setup() {
 
 @test 'set-build-dir-command: Create empty directory.' {
 
-    export BUILD_DIR="./build/"
+    export BUILD_DIR="./docker-publisher-build/"
 
     [ ! -d "${BUILD_DIR}" ]
     [ ! -f "${BUILD_DIR}orderedInheritanceList.txt" ]
@@ -22,7 +22,7 @@ setup() {
 
 @test 'set-build-dir-command: Remove old directory with files and create empty directory.' {
 
-    export BUILD_DIR="./build/"
+    export BUILD_DIR="./docker-publisher-build/"
 
     mkdir -p "${BUILD_DIR}"
 

--- a/src/tests/set-build-dir.bats
+++ b/src/tests/set-build-dir.bats
@@ -3,13 +3,41 @@ setup() {
     source ./src/scripts/set-build-dir.sh
 }
 
-@test 'set-build-dir-command: Create empty build directory' {
+@test 'set-build-dir-command: Create empty directory' {
 
     export BUILD_DIR="./build/"
 
-    ! [ -d "${BUILD_DIR}" ]
+    [ ! -d "${BUILD_DIR}" ]
+    [ ! -f "${BUILD_DIR}orderedInheritanceList.txt" ]
+    [ ! -f "${BUILD_DIR}unorderedInheritanceList.txt" ]
 
     SetBuildDir
 
     [ -d "${BUILD_DIR}" ]
+    [ ! -f "${BUILD_DIR}orderedInheritanceList.txt" ]
+    [ ! -f "${BUILD_DIR}unorderedInheritanceList.txt" ]
+
+    rm -rf "${BUILD_DIR}"
+}
+
+@test 'set-build-dir-command: Remove old directory with files and create empty directory' {
+
+    export BUILD_DIR="./build/"
+
+    mkdir -p "${BUILD_DIR}"
+
+    echo "namespace/test-image" >> "${BUILD_DIR}orderedInheritanceList.txt"
+    echo "namespace/test-image" >> "${BUILD_DIR}unorderedInheritanceList.txt"
+
+    [ -d "${BUILD_DIR}" ]
+    [ -f "${BUILD_DIR}orderedInheritanceList.txt" ]
+    [ -f "${BUILD_DIR}unorderedInheritanceList.txt" ]
+
+    SetBuildDir
+
+    [ -d "${BUILD_DIR}" ]
+    [ ! -f "${BUILD_DIR}orderedInheritanceList.txt" ]
+    [ ! -f "${BUILD_DIR}unorderedInheritanceList.txt" ]
+
+    rm -rf "${BUILD_DIR}"
 }


### PR DESCRIPTION
## Description:

- Added `src/scripts/set-build-dir.sh` script for creating `./build/` directory.
- Added `src/scripts/remove-build-dir.sh` script for removing `./build/` directory.
- Added `src/commands/set-build-dir.yml` command configuration.
- Added `src/commands/remove-build-dir.yml` command configuration.
- Added `src/tests/set-build-dir.bats` script for unit testing.
- Added `src/tests/remove-build-dir.bats` script for unit testing.
- Added description for both commands.
- Updated `CHANGELOG.md`.

## Motivation:

The idea behind this PR is to add commands for creating and removing `./build/` directory which will be used for storing list files that are necessary for docker automated publishing.

 **Closes Issues:**
-  [#ODP-2](https://github.com/serbiatech/ci-orb-docker-publisher/issues/4)

## Checklist:

- [x] All new features have descriptions in their appropriate `README.md.` files.
- [x] All new features have descriptions in their appropriate `yml` files.
- [x] All new features are covered with tests.
- [x] Changelog has been updated.